### PR TITLE
Re-add Hyva dashboard support

### DIFF
--- a/Model/Widget/QualityPatches.php
+++ b/Model/Widget/QualityPatches.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Copyright © Rob Aimes - https://aimes.dev/
+ * https://github.com/robaimes
+ */
+
+declare(strict_types=1);
+
+namespace Aimes\QualityPatchesUi\Model\Widget;
+
+use Aimes\QualityPatchesUi\Model\QualityPatches as PatchesModel;
+use Hyva\AdminDashboardApi\Api\ConfigurationKeys;
+use Hyva\AdminDashboardApi\Api\V1\WidgetContextInterface;
+use Hyva\AdminDashboardApi\Api\V1\WidgetInstanceInterface;
+use Hyva\AdminDashboardApi\Api\V1\WidgetTypeInterface;
+use Magento\Framework\Phrase;
+
+class QualityPatches implements WidgetTypeInterface
+{
+    private const string PROP_CATEGORIES = 'patch_categories';
+    private const string PROP_STATUSES = 'patch_statuses';
+
+    /**
+     * @param PatchesModel $patches
+     */
+    public function __construct(
+        private readonly PatchesModel $patches,
+    ) {
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     *
+     * @return array
+     */
+    public function getConfigurableProperties(
+        WidgetContextInterface $ctx
+    ): array {
+        $patches = $this->patches->getAllPatches();
+
+        return array_merge(
+            $ctx->getConfigurableProperties(),
+            [
+                self::PROP_CATEGORIES => [
+                    'label' => __('Patch Category'),
+                    'input' => [
+                        'type' => 'select',
+                        'options' => $this->getUniqueValues($patches, 'Category'),
+                        'attributes' => [
+                            'multiple' => true,
+                            'required' => true,
+                            'size' => 15,
+                        ],
+                    ],
+                ],
+                self::PROP_STATUSES => [
+                    'label' => __('Patch Status'),
+                    'note' => __('Status reported from the Magento Quality Patch tools may be inaccurate if your installed versions are outdated, or patches are applied via other means.'),
+                    'input' => [
+                        'type' => 'select',
+                        'options' => $this->getUniqueValues($patches, 'Status'),
+                        'attributes' => [
+                            'multiple' => true,
+                            'required' => true,
+                            'size' => 3,
+                        ],
+                    ],
+                ]
+            ]
+        );
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     *
+     * @return array
+     */
+    public function getDisplayProperties(WidgetContextInterface $ctx): array
+    {
+        return $ctx->getDisplayProperties();
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     * @param WidgetInstanceInterface $widgetInstance
+     *
+     * @return mixed
+     */
+    public function getDisplayData(
+        WidgetContextInterface $ctx,
+        WidgetInstanceInterface $widgetInstance
+    ): mixed {
+        $allPatches = $this->patches->getAllPatches();
+        $categories = $widgetInstance->getPropertyValue(ConfigurationKeys::CONFIGURABLE_PROPERTIES, self::PROP_CATEGORIES);
+        $statuses = $widgetInstance->getPropertyValue(ConfigurationKeys::CONFIGURABLE_PROPERTIES, self::PROP_STATUSES) ?? [];
+        $filteredPatches = array_filter($allPatches, function ($patch) use ($categories, $statuses) {
+            return !empty(array_intersect(explode("\n", $patch['Category']), $categories))
+                && in_array($patch['Status'], $statuses);
+        });
+
+        $data = [
+            'headings' => $this->getHeadings(),
+            'rows' => [],
+        ];
+
+        foreach ($filteredPatches as $patch) {
+            if (!isset($patch['Id'], $patch['Status'], $patch['Category'], $patch['Title'])) {
+                continue;
+            }
+
+            $data['rows'][] = [
+                'values' => [
+                    $patch['Id'],
+                    $patch['Status'],
+                    str_replace("\n", ', ', $patch['Category']),
+                    $patch['Title'],
+                ],
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     * @param WidgetInstanceInterface|null $widgetInstance
+     *
+     * @return Phrase
+     */
+    public function getTitle(WidgetContextInterface $ctx, ?WidgetInstanceInterface $widgetInstance): Phrase
+    {
+        return $ctx->getTitle();
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     * @param WidgetInstanceInterface|null $widgetInstance
+     *
+     * @return array
+     */
+    public function getTrailingAction(WidgetContextInterface $ctx, ?WidgetInstanceInterface $widgetInstance): array
+    {
+        return $ctx->getTrailingAction();
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     * @param WidgetInstanceInterface|null $widgetInstance
+     *
+     * @return bool
+     */
+    public function isAllowed(WidgetContextInterface $ctx, ?WidgetInstanceInterface $widgetInstance): bool
+    {
+        return $ctx->isAllowed($widgetInstance);
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     * @param WidgetInstanceInterface $widgetInstance
+     *
+     * @return WidgetInstanceInterface]
+     */
+    public function beforeSave(WidgetContextInterface $ctx, WidgetInstanceInterface $widgetInstance): WidgetInstanceInterface
+    {
+        return $widgetInstance;
+    }
+
+    /**
+     * @param WidgetContextInterface $ctx
+     * @param WidgetInstanceInterface $widgetInstance
+     *
+     * @return WidgetInstanceInterface
+     */
+    public function afterSave(WidgetContextInterface $ctx, WidgetInstanceInterface $widgetInstance): WidgetInstanceInterface
+    {
+        return $widgetInstance;
+    }
+
+    /**
+     * @return array
+     */
+    private function getHeadings(): array
+    {
+        return [
+            __('Patch ID'),
+            __('Status'),
+            __('Category'),
+            __('Title'),
+        ];
+    }
+
+    /**
+     * @param array $patches
+     * @param string $key
+     *
+     * @return array
+     */
+    public function getUniqueValues(array $patches, string $key): array
+    {
+        $values = array_unique(explode("\n", implode("\n", array_column($patches, $key))));
+        sort($values);
+
+        return array_map(fn ($value) => ['label' => $value, 'value' => $value], $values);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Compatible with Hyvä Commerce
 - Notify users of any updates available to the following packages (when viewing the grid), as a new version may contain new patches:
   - `magento/magento-cloud-patches`
   - `magento/quality-patches`
-- Integration with [Hyvä Admin Dashboard][hyva-dashboard] via the [integration module][dashboard-integration]
+- Integration with [Hyvä Admin Dashboard][hyva-dashboard], if installed
 
 ## Requirements
 * Magento Open Source or Adobe Commerce version `2.4.x`
@@ -41,4 +41,3 @@ Navigate to `Reports -> Patch Status -> Quality Patches` in the admin area
 [gpl]:https://www.gnu.org/licenses/gpl-3.0.en.html
 [author]:https://aimes.dev/
 [hyva-dashboard]:https://docs.hyva.io/hyva-commerce/features/admin-dashboard/index.html
-[dashboard-integration]:https://github.com/robaimes/magento2-quality-patches-ui-hyva-dashboard-widget

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Compatible with Hyvä Commerce
 - Notify users of any updates available to the following packages (when viewing the grid), as a new version may contain new patches:
   - `magento/magento-cloud-patches`
   - `magento/quality-patches`
-- Integration with [Hyvä Admin Dashboard][hyva-dashboard], if installed
+- Integration with [Hyvä Admin Dashboard][hyva-dashboard]
 
 ## Requirements
 * Magento Open Source or Adobe Commerce version `2.4.x`

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,11 @@
         "magento/magento-cloud-patches": "^1.0.20",
         "magento/quality-patches": "^1.1"
     },
+    "conflict": {
+        "aimes/module-quality-patches-ui-hyva-dashboard-widget": "*"
+    },
     "suggest": {
-        "aimes/module-quality-patches-ui-hyva-dashboard-widget": "Hyvä Dashboard compatibility — Adds a Patch Status dashboard widget"
+        "hyva-themes/commerce-module-admin-dashboard-api": "Hyvä Dashboard compatibility — Requires Hyvä Commerce license"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,12 @@
     ],
     "require": {
         "aimes/magento2-module-substratum": "^1.0",
+        "hyva-themes/commerce-module-admin-dashboard-api": "^2.0 || ^3.0",
         "magento/magento-cloud-patches": "^1.0.20",
         "magento/quality-patches": "^1.1"
     },
     "conflict": {
         "aimes/module-quality-patches-ui-hyva-dashboard-widget": "*"
-    },
-    "suggest": {
-        "hyva-themes/commerce-module-admin-dashboard-api": "Hyvä Dashboard compatibility — Requires Hyvä Commerce license"
     },
     "autoload": {
         "psr-4": {

--- a/etc/adminhtml/hyva_dashboard_widget.xml
+++ b/etc/adminhtml/hyva_dashboard_widget.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Rob Aimes - https://aimes.dev/
+ * https://github.com/robaimes
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_AdminDashboardApi:etc/adminhtml/hyva_dashboard_widget.xsd">
+    <widget id="aimes_quality_patches_ui">
+        <class>\Aimes\QualityPatchesUi\Model\Widget\QualityPatches</class>
+        <display_type>table</display_type>
+        <title>Quality Patches</title>
+        <acl>Aimes_QualityPatchesUi::view</acl>
+        <category>system</category>
+        <tags>magento,patch,quality,report</tags>
+        <min_height>6</min_height>
+        <min_width>2</min_width>
+        <icon>folder-git-2</icon>
+    </widget>
+</config>


### PR DESCRIPTION
With the release of [Hyva Commerce 1.3.0](https://docs.hyva.io/hyva-commerce/upgrading/changelog.html#130-2026-06-30), brings a new [API for dashboard widgets](https://docs.hyva.io/hyva-commerce/upgrading/changelog.html#300-admin-dashboard-api). Widget classes now use composition rather than inheritance meaning we have no runtime / compiliation issues if the Hyva Dashboard modules are not installed.

- (re)Add support for Hyva Dashboard Widgets
- Deprecates the package [aimes/module-quality-patches-ui-hyva-dashboard-widget](https://github.com/robaimes/magento2-quality-patches-ui-hyva-dashboard-widget)